### PR TITLE
Add the modal window as a parameter of the show() method. 

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/standard/DemoView.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/standard/DemoView.java
@@ -133,7 +133,7 @@ public class DemoView extends VBox {
   }
 
   private void setupEventHandlers() {
-    preferencesMenuItem.setOnAction(e -> preferencesFx.show());
+    preferencesMenuItem.setOnAction(e -> preferencesFx.show(true));
   }
 
   private void setupListeners() {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -104,7 +104,16 @@ public class PreferencesFx {
    * Shows the PreferencesFX dialog.
    */
   public void show() {
-    new PreferencesFxDialog(preferencesFxModel, preferencesFxView);
+    // by default, modal is false for retro-compatibility
+    show(false);
+  }
+
+  /**
+   * Show the PreferencesFX dialog.
+   * @param modal window or not modal, that's the question.
+   */
+  public void show(boolean modal) {
+    new PreferencesFxDialog(preferencesFxModel, preferencesFxView, modal);
   }
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -34,6 +34,7 @@ public class PreferencesFxDialog extends DialogPane {
   private StorageHandler storageHandler;
   private boolean persistWindowState;
   private boolean saveSettings;
+  private boolean modalWindow;
   private ButtonType closeWindowBtnType = ButtonType.CLOSE;
   private ButtonType cancelBtnType = ButtonType.CANCEL;
 
@@ -42,10 +43,12 @@ public class PreferencesFxDialog extends DialogPane {
    *
    * @param model             the model of PreferencesFX
    * @param preferencesFxView the master view to be display in this {@link DialogPane}
+   * @param modal             flag to set the dialog as modal (true) or not
    */
-  public PreferencesFxDialog(PreferencesFxModel model, PreferencesFxView preferencesFxView) {
+  public PreferencesFxDialog(PreferencesFxModel model, PreferencesFxView preferencesFxView, boolean modal) {
     this.model = model;
     this.preferencesFxView = preferencesFxView;
+    this.modalWindow = modal;
     persistWindowState = model.isPersistWindowState();
     saveSettings = model.isSaveSettings();
     storageHandler = model.getStorageHandler();
@@ -64,7 +67,11 @@ public class PreferencesFxDialog extends DialogPane {
     dialog.setTitle("PreferencesFx");
     dialog.setResizable(true);
     getButtonTypes().addAll(closeWindowBtnType, cancelBtnType);
-    dialog.initModality(Modality.NONE);
+    if (modalWindow) {
+      dialog.initModality(Modality.APPLICATION_MODAL);
+    } else {
+      dialog.initModality(Modality.NONE);
+    }
     dialog.setDialogPane(this);
     setContent(preferencesFxView);
   }


### PR DESCRIPTION
Close issue #7 

- The current behavior is not changed as by default the dialog is not modal.
- The standard demo has been also updated to be modal, but not the other ones.