### PR TITLE
Fix hashing method

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
@@ -178,6 +178,14 @@ public class StorageHandlerImpl implements StorageHandler {
   public Object loadObject(String breadcrumb, Object defaultObject) {
     String serializedDefault = gson.toJson(defaultObject);
     String json = preferences.get(hash(breadcrumb), serializedDefault);
+    if (json == serializedDefault) {
+      // try to get preferences value with legacy hashing method
+      json = preferences.get(deprecatedHash(breadcrumb), serializedDefault);
+      if (json != serializedDefault) {
+        LOGGER.warn("Preferences value of %s was loaded using the legacy hashing method. "
+            + "Value will be saved using the new hashing method with next save.", breadcrumb);
+      }
+    }
     return gson.fromJson(json, Object.class);
   }
   // asciidoctor Documentation - end::storageHandlerLoad[]
@@ -199,6 +207,14 @@ public class StorageHandlerImpl implements StorageHandler {
   ) {
     String serializedDefault = gson.toJson(defaultObservableList);
     String json = preferences.get(hash(breadcrumb), serializedDefault);
+    if (json == serializedDefault) {
+      // try to get preferences value with legacy hashing method
+      json = preferences.get(deprecatedHash(breadcrumb), serializedDefault);
+      if (json != serializedDefault) {
+        LOGGER.warn("Preferences value of %s was loaded using the legacy hashing method. "
+            + "Value will be saved using the new hashing method with next save.", breadcrumb);
+      }
+    }
     return FXCollections.observableArrayList(gson.fromJson(json, ArrayList.class));
   }
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
@@ -176,16 +176,7 @@ public class StorageHandlerImpl implements StorageHandler {
    */
   // asciidoctor Documentation - tag::storageHandlerLoad[]
   public Object loadObject(String breadcrumb, Object defaultObject) {
-    String serializedDefault = gson.toJson(defaultObject);
-    String json = preferences.get(hash(breadcrumb), serializedDefault);
-    if (json == serializedDefault) {
-      // try to get preferences value with legacy hashing method
-      json = preferences.get(deprecatedHash(breadcrumb), serializedDefault);
-      if (json != serializedDefault) {
-        LOGGER.warn("Preferences value of %s was loaded using the legacy hashing method. "
-            + "Value will be saved using the new hashing method with next save.", breadcrumb);
-      }
-    }
+    String json = getSerializedPreferencesValue(breadcrumb, gson.toJson(defaultObject));
     return gson.fromJson(json, Object.class);
   }
   // asciidoctor Documentation - end::storageHandlerLoad[]
@@ -205,7 +196,11 @@ public class StorageHandlerImpl implements StorageHandler {
       String breadcrumb,
       ObservableList defaultObservableList
   ) {
-    String serializedDefault = gson.toJson(defaultObservableList);
+    String json = getSerializedPreferencesValue(breadcrumb, gson.toJson(defaultObservableList));
+    return FXCollections.observableArrayList(gson.fromJson(json, ArrayList.class));
+  }
+
+  private String getSerializedPreferencesValue(String breadcrumb, String serializedDefault) {
     String json = preferences.get(hash(breadcrumb), serializedDefault);
     if (json == serializedDefault) {
       // try to get preferences value with legacy hashing method
@@ -215,7 +210,7 @@ public class StorageHandlerImpl implements StorageHandler {
             + "Value will be saved using the new hashing method with next save.", breadcrumb);
       }
     }
-    return FXCollections.observableArrayList(gson.fromJson(json, ArrayList.class));
+    return json;
   }
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
@@ -206,7 +206,7 @@ public class StorageHandlerImpl implements StorageHandler {
       // try to get preferences value with legacy hashing method
       json = preferences.get(deprecatedHash(breadcrumb), serializedDefault);
       if (json != serializedDefault) {
-        LOGGER.warn("Preferences value of %s was loaded using the legacy hashing method. "
+        LOGGER.warn("Preferences value of {} was loaded using the legacy hashing method. "
             + "Value will be saved using the new hashing method with next save.", breadcrumb);
       }
     }


### PR DESCRIPTION
Our previous implementation of the SHA256 hashing of the keys before saving them in `StorageHandlerImpl` returns a string in wrong encoding in some circumstances, leading to an `InvalidPreferencesFormatException` upon loading, see #53.

Properly implemented the hashing in all circumstances and implemented loading of preferences with the old hashing method in case the preferences are still in this format, while being saved in the new format the next time. This makes this change a non-breaking change and allows some time for the users of PreferencesFX to migrate to the new method.