### PR TITLE
Make cancel cancel again

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/AppStarter.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/AppStarter.java
@@ -25,7 +25,7 @@ public class AppStarter extends Application {
     for(Pane pane : examples)
       tabPane.getTabs().add(new Tab(pane.getClass().getSimpleName().replace("Example", ""), pane));
     Scene myScene = new Scene(tabPane);
-    primaryStage.setTitle("PreferencesFx Demo");
+    primaryStage.setTitle("PreferencesFX Demo");
     primaryStage.setScene(myScene);
     primaryStage.setWidth(1000);
     primaryStage.setHeight(700);

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/PreferencesFxModel.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/PreferencesFxModel.java
@@ -309,6 +309,7 @@ public class PreferencesFxModel {
    * Saves the settings, when {@link #isSaveSettings()} returns {@code true}.
    */
   public void saveSettings() {
+    LOGGER.trace("Save");
     if (isSaveSettings()) {
       saveSettingValues();
       fireEvent(PreferencesFxEvent.preferencesSavedEvent());
@@ -317,6 +318,7 @@ public class PreferencesFxModel {
   }
 
   public void discardChanges() {
+    LOGGER.trace("Discard");
     history.clear(true);
     // save settings after undoing them
     if (saveSettings) {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -1,6 +1,5 @@
 package com.dlsc.preferencesfx.view;
 
-import com.dlsc.preferencesfx.history.History;
 import com.dlsc.preferencesfx.history.view.HistoryDialog;
 import com.dlsc.preferencesfx.model.PreferencesFxModel;
 import com.dlsc.preferencesfx.util.Constants;
@@ -83,10 +82,18 @@ public class PreferencesFxDialog extends DialogPane {
 
   private void setupDialogClose() {
     dialog.setOnCloseRequest(e -> {
-      if (persistWindowState) {
-        saveWindowState();
+      LOGGER.trace("Closing because of dialog close request");
+      ButtonType resultButton = (ButtonType) dialog.resultProperty().getValue();
+      if (ButtonType.CANCEL.equals(resultButton)) {
+        LOGGER.trace("Dialog - Cancel Button was pressed");
+        model.discardChanges();
+      } else {
+        LOGGER.trace("Dialog - Close Button or 'x' was pressed");
+        if (persistWindowState) {
+          saveWindowState();
+        }
+        model.saveSettings();
       }
-     model.saveSettings();
     });
   }
 
@@ -130,16 +137,6 @@ public class PreferencesFxDialog extends DialogPane {
     LOGGER.trace("Setting Buttons up");
     final Button closeBtn = (Button) lookupButton(closeWindowBtnType);
     final Button cancelBtn = (Button) lookupButton(cancelBtnType);
-
-    History history = model.getHistory();
-    cancelBtn.setOnAction(event -> {
-      LOGGER.trace("Cancel Button was pressed");
-      model.discardChanges();
-    });
-    closeBtn.setOnAction(event -> {
-      LOGGER.trace("Close Button was pressed");
-      history.clear(false);
-    });
 
     cancelBtn.visibleProperty().bind(model.buttonsVisibleProperty());
     closeBtn.visibleProperty().bind(model.buttonsVisibleProperty());

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -73,7 +73,7 @@ public class PreferencesFxDialog extends DialogPane {
   }
 
   private void layoutForm() {
-    dialog.setTitle("PreferencesFx");
+    dialog.setTitle("Preferences");
     dialog.setResizable(true);
     getButtonTypes().addAll(closeWindowBtnType, cancelBtnType);
     dialog.setDialogPane(this);

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
@@ -51,7 +51,7 @@ public class PreferencesFxPresenter implements Presenter {
         LOGGER.trace("addEventHandler on Window close request to save settings");
         newScene.getWindow()
             .addEventHandler(WindowEvent.WINDOW_CLOSE_REQUEST, event -> {
-              LOGGER.trace("saveSettings");
+              LOGGER.trace("saveSettings because of WINDOW_CLOSE_REQUEST");
               model.saveSettings();
             });
       }


### PR DESCRIPTION
There was a bug that when pressing "Cancel" on the dialog, the changes would not be discarded. This was because `setOnCloseRequest` was run first before the action defined on the cancel button, which meant the preferences would get saved first and the history cleared, so there was nothing for the action on the cancel button to undo.