### PR TITLE
Fix demo saving bug

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/extended/ExtendedExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/extended/ExtendedExample.java
@@ -130,7 +130,7 @@ public class ExtendedExample extends StackPane {
   ObjectProperty<String> closingToolObj = new SimpleObjectProperty<>("Ask");
 
   private PreferencesFx createPreferences() {
-    return PreferencesFx.of(AppStarter.class,
+    return PreferencesFx.of(ExtendedExample.class,
         Category.of("General",
             Group.of("Greeting",
                 Setting.of("Welcome Text", welcomeText)

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/i18n/InternationalizedExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/i18n/InternationalizedExample.java
@@ -88,7 +88,7 @@ public class InternationalizedExample extends StackPane {
   }
 
   private PreferencesFx createPreferences() {
-    return PreferencesFx.of(AppStarter.class,
+    return PreferencesFx.of(InternationalizedExample.class,
         Category.of("general",
             Group.of("greeting",
                 Setting.of("welcome", welcomeText)

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/node/NodeExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/node/NodeExample.java
@@ -85,7 +85,7 @@ public class NodeExample extends StackPane {
 
   private PreferencesFx createPreferences() {
     // asciidoctor Documentation - tag::setupPreferences[]
-    return PreferencesFx.of(AppStarter.class,
+    return PreferencesFx.of(NodeExample.class,
         Category.of("General",
             Group.of("Greeting",
                 Setting.of("Welcome Text", welcomeText)

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/oneCategory/OneCategoryExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/oneCategory/OneCategoryExample.java
@@ -42,7 +42,7 @@ public class OneCategoryExample extends StackPane {
   }
 
   private PreferencesFx createPreferences() {
-    return PreferencesFx.of(AppStarter.class,
+    return PreferencesFx.of(OneCategoryExample.class,
         Category.of("General",
             Group.of("Greeting",
                 Setting.of("Welcome Text", welcomeText)

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/standard/StandardExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/standard/StandardExample.java
@@ -81,7 +81,7 @@ public class StandardExample extends StackPane {
 
   private PreferencesFx createPreferences() {
     // asciidoctor Documentation - tag::setupPreferences[]
-    return PreferencesFx.of(AppStarter.class,
+    return PreferencesFx.of(StandardExample.class,
         Category.of("General",
             Group.of("Greeting",
                 Setting.of("Welcome Text", welcomeText)


### PR DESCRIPTION
The demos currently all save under `AppStarter.class`, which means changes in the standard demo will not be saved, but the changes in the node demo will be the ones that are being saved.
Changed every demo to use their own saving class, so they don't override each other.