### PR TITLE
Remove guava dependency

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/extended/ExtendedExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/extended/ExtendedExample.java
@@ -9,7 +9,6 @@ import com.dlsc.preferencesfx.formsfx.view.controls.IntegerSliderControl;
 import com.dlsc.preferencesfx.model.Category;
 import com.dlsc.preferencesfx.model.Group;
 import com.dlsc.preferencesfx.model.Setting;
-import com.google.common.collect.Lists;
 import java.util.Arrays;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -85,7 +84,7 @@ public class ExtendedExample extends StackPane {
 //  Theme
   ListProperty<String> themesLst = new SimpleListProperty<>(
       FXCollections.observableArrayList(
-          Lists.newArrayList("IntelliJ", "Darkula", "Windows")
+          Arrays.asList("IntelliJ", "Darkula", "Windows")
       )
   );
   ObjectProperty<String> themesObj = new SimpleObjectProperty<>("IntelliJ");
@@ -93,7 +92,7 @@ public class ExtendedExample extends StackPane {
   //  IDE
   ListProperty<String> ideLst = new SimpleListProperty<>(
       FXCollections.observableArrayList(
-          Lists.newArrayList("Subpixel", "Greyscale", "No Antializing")
+          Arrays.asList("Subpixel", "Greyscale", "No Antializing")
       )
   );
   ObjectProperty<String> ideObj = new SimpleObjectProperty<>("Subpixel");
@@ -101,7 +100,7 @@ public class ExtendedExample extends StackPane {
   //  Editor
   ListProperty<String> editorLst = new SimpleListProperty<>(
       FXCollections.observableArrayList(
-          Lists.newArrayList("Subpixel", "Greyscale", "No Antializing")
+          Arrays.asList("Subpixel", "Greyscale", "No Antializing")
       )
   );
   ObjectProperty<String> editorObj = new SimpleObjectProperty<>("Subpixel");
@@ -109,7 +108,7 @@ public class ExtendedExample extends StackPane {
   //  Font size
   ListProperty<String> fontLst = new SimpleListProperty<>(
       FXCollections.observableArrayList(
-          Lists.newArrayList("8", "10", "12", "14", "18", "20", "22", "24", "36", "72")
+          Arrays.asList("8", "10", "12", "14", "18", "20", "22", "24", "36", "72")
       )
   );
   ObjectProperty<String> fontObj = new SimpleObjectProperty<>("24");
@@ -117,7 +116,7 @@ public class ExtendedExample extends StackPane {
   //  Project opening
   ListProperty<String> projectOpeningLst = new SimpleListProperty<>(
       FXCollections.observableArrayList(
-          Lists.newArrayList("Open project in new window", "Open project in the same window", "Confirm window to open project in")
+          Arrays.asList("Open project in new window", "Open project in the same window", "Confirm window to open project in")
       )
   );
   ObjectProperty<String> projectOpeningObj = new SimpleObjectProperty<>("Open project in new window");
@@ -125,7 +124,7 @@ public class ExtendedExample extends StackPane {
   //  Closing tool window
   ListProperty<String> closingToolLst = new SimpleListProperty<>(
       FXCollections.observableArrayList(
-          Lists.newArrayList("Terminate process", "Disconnect (if available)", "Ask")
+          Arrays.asList("Terminate process", "Disconnect (if available)", "Ask")
       )
   );
   ObjectProperty<String> closingToolObj = new SimpleObjectProperty<>("Ask");

--- a/preferencesfx/pom.xml
+++ b/preferencesfx/pom.xml
@@ -103,7 +103,6 @@
                     <windowtitle>PreferencesFX API</windowtitle>
                     <additionalJOption>-J-Djavafx.javadoc=true
                     </additionalJOption>
-                    <failOnError>false</failOnError>
                     <docfilessubdirs>true</docfilessubdirs>
                 </configuration>
                 <executions>
@@ -127,6 +126,7 @@
 
             <!-- JUnit Tests -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
                 <!-- Only Java 9+
@@ -172,7 +172,6 @@
     </build>
 
     <dependencies>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -198,20 +197,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.dlsc.formsfx</groupId>
             <artifactId>formsfx-core</artifactId>
             <version>1.3.0</version>
@@ -224,6 +209,20 @@
             <version>1.7.25</version>
         </dependency>
 
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/preferencesfx/pom.xml
+++ b/preferencesfx/pom.xml
@@ -173,12 +173,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
             <version>8.40.14</version>

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroup.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroup.java
@@ -23,7 +23,7 @@ package com.dlsc.preferencesfx.formsfx.view.renderer;
 import com.dlsc.formsfx.model.structure.Field;
 import com.dlsc.formsfx.model.structure.Group;
 import com.dlsc.formsfx.model.util.TranslationService;
-import com.google.common.base.Strings;
+import com.dlsc.preferencesfx.util.Strings;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/history/Change.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/history/Change.java
@@ -1,10 +1,10 @@
 package com.dlsc.preferencesfx.history;
 
 import com.dlsc.preferencesfx.model.Setting;
-import com.google.common.collect.Lists;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import javafx.beans.binding.Bindings;
@@ -87,8 +87,8 @@ public class Change<P> {
    */
   public Change(Setting setting, P oldValue, P newValue) {
     this(setting, false);
-    this.oldList.set(FXCollections.observableArrayList(Lists.newArrayList(oldValue)));
-    this.newList.set(FXCollections.observableArrayList(Lists.newArrayList(newValue)));
+    this.oldList.set(FXCollections.observableArrayList(Arrays.asList(oldValue)));
+    this.newList.set(FXCollections.observableArrayList(Arrays.asList(newValue)));
   }
 
   private void setupBindings() {
@@ -192,7 +192,7 @@ public class Change<P> {
   }
 
   public void setNewValue(P newValue) {
-    this.newList.set(FXCollections.observableArrayList(Lists.newArrayList(newValue)));
+    this.newList.set(FXCollections.observableArrayList(Arrays.asList(newValue)));
   }
 
   public Setting getSetting() {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Category.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Category.java
@@ -4,8 +4,8 @@ import static com.dlsc.preferencesfx.util.Constants.BREADCRUMB_DELIMITER;
 
 import com.dlsc.formsfx.model.util.TranslationService;
 import com.dlsc.preferencesfx.util.PreferencesFxUtils;
+import com.dlsc.preferencesfx.util.Strings;
 import com.dlsc.preferencesfx.view.CategoryView;
-import com.google.common.base.Strings;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesFxUtils.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesFxUtils.java
@@ -5,7 +5,6 @@ import static com.dlsc.preferencesfx.util.Ascii.containsIgnoreCase;
 import com.dlsc.preferencesfx.model.Category;
 import com.dlsc.preferencesfx.model.Group;
 import com.dlsc.preferencesfx.model.Setting;
-import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/SearchHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/SearchHandler.java
@@ -6,7 +6,6 @@ import com.dlsc.preferencesfx.model.Category;
 import com.dlsc.preferencesfx.model.Group;
 import com.dlsc.preferencesfx.model.PreferencesFxModel;
 import com.dlsc.preferencesfx.model.Setting;
-import com.google.common.base.Strings;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
@@ -13,9 +13,7 @@ import static com.dlsc.preferencesfx.util.Constants.WINDOW_POS_Y;
 import static com.dlsc.preferencesfx.util.Constants.WINDOW_WIDTH;
 
 import com.dlsc.preferencesfx.model.Setting;
-import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -261,10 +259,7 @@ public class StorageHandlerImpl implements StorageHandler {
    * @return SHA-256 representation of breadcrumb
    */
   public String hash(String key) {
-    Objects.requireNonNull(key);
-    return Hashing.sha256()
-        .hashString(key, StandardCharsets.UTF_8)
-        .toString();
+    return Strings.sha256(key);
   }
 
   public Preferences getPreferences() {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/Strings.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/Strings.java
@@ -1,12 +1,61 @@
 package com.dlsc.preferencesfx.util;
 
+import static java.util.Objects.requireNonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
 /**
  * Helper methods for working with strings.
  */
 public class Strings {
 
+  private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
+
+  /**
+   * Checks if a string is null or empty.
+   *
+   * @param string the string to test, may be {@code null}.
+   * @return {@code true} iff the string is not null and not empty
+   */
   public static boolean isNullOrEmpty(String string) {
     return string == null || string.isEmpty();
+  }
+
+  /**
+   * Calculates the SHA-256 digest of a string.
+   *
+   * @param string the string to digest, must not be {@code null}.
+   * @return the SHA-256 digest of the input string
+   */
+  public static String sha256(String string) {
+    requireNonNull(string);
+    try {
+      final MessageDigest digest = MessageDigest.getInstance("sha-256");
+      final byte[] hash = digest.digest(string.getBytes(StandardCharsets.UTF_8));
+      return hexString(hash);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Calculates the HEX representation of a byte array.
+   *
+   * @param bytes the byte array, must not be {@code null}.
+   * @return the HEX representation of the byte array.
+   */
+  public static String hexString(byte[] bytes) {
+    requireNonNull(bytes);
+    final int numBytes = bytes.length;
+    char[] hexChars = new char[numBytes * 2];
+    for (int i = 0; i < numBytes; i++) {
+      int v = bytes[i] & 0xFF;
+      hexChars[i * 2] = HEX_ARRAY[v >>> 4];
+      hexChars[(i * 2) + 1] = HEX_ARRAY[v & 0x0F];
+    }
+    return new String(hexChars);
   }
 
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/Strings.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/Strings.java
@@ -1,0 +1,12 @@
+package com.dlsc.preferencesfx.util;
+
+/**
+ * Helper methods for working with strings.
+ */
+public class Strings {
+
+  public static boolean isNullOrEmpty(String string) {
+    return string == null || string.isEmpty();
+  }
+
+}

--- a/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
+++ b/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
@@ -1,5 +1,8 @@
 package com.dlsc.preferencesfx.util;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import org.junit.After;
@@ -86,5 +89,12 @@ public class StorageHandlerImplTest {
 
   @Test
   public void loadObservableList() {
+  }
+
+  @Test
+  public void shaHashing() {
+    StorageHandlerImpl storageHandler = new StorageHandlerImpl(StorageHandlerImplTest.class);
+    final String result = storageHandler.hash("test");
+    assertThat(result, is("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"));
   }
 }


### PR DESCRIPTION
Removes all usages of guava as well as the dependency in the pom file.
Guava is still on the classpath as a transitive dependency of `org.eclipse.fx.ui.controls`.
